### PR TITLE
Update solc version information in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more details, please refer to these documentations https://goethereumbook.or
 ## Prerequisites
 
 1. The latest Go version.
-2. Solidity compiler version <= 0.8.26 (Neon EVM supports solidity <= 0.8.26).
+2. Solidity compiler version <= 0.8.25 (Neon EVM supports solidity <= 0.8.26 but Homebrew only supports 0.8.25 for now).
 
 ### Solc installation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more details, please refer to these documentations https://goethereumbook.or
 ## Prerequisites
 
 1. The latest Go version.
-2. Solidity compiler version <= 0.8.24 (Neon EVM supports solidity <= 0.8.24).
+2. Solidity compiler version <= 0.8.26 (Neon EVM supports solidity <= 0.8.26).
 
 ### Solc installation
 


### PR DESCRIPTION
This PR adds an update to the README about new solidity version `0.8.25` compatibility with Neon EVM. The solidity smart contracts included in this repository works with compilers `>=0.8.20`. The testing is not complete with `0.8.26` since homebrew solidity version is updated till `0.8.25`.